### PR TITLE
feat: support stacking icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,23 @@ The `fa-icon` function passes args to `text`, so you can customize the icon by p
 
 `#fa-icon("chess-queen", fill: blue)`
 
+#### Stacking icons
+
+The `fa-stack` function can be used to create stacked icons:
+
+`#fa-stack(fa-icon-args: (solid: true), "square", ("chess-queen", (fill: white, size: 5.5pt)))`
+
+Declaration is `fa-stack(box-args: (:), grid-args: (:), fa-icon-args: (:), ..icons)`
+
+- The order of the icons is from the bottom to the top.
+- `fa-icon-args` is used to set the default args for all icons.
+- You can also control the internal `box` and `grid` by passing the `box-args` and `grid-args` to the `fa-stack` function.
+- Currently, four types of icons are supported. The first three types leverage the `fa-icon` function, and the last type is just a content you want to put in the stack.
+  - `str`, e.g., `"square"`
+  - `array`, e.g., `("chess-queen", (fill: white, size: 5.5pt))`
+  - `arguments`, e.g. `arguments("chess-queen", solid: true, fill: white)`
+  - `content`, e.g. `fa-chess-queen(solid: true, fill: white)`
+
 #### Known Issues
 
 - [typst#2578](https://github.com/typst/typst/issues/2578) [typst-fontawesome#2](https://github.com/duskmoon314/typst-fontawesome/issues/2)

--- a/example.typ
+++ b/example.typ
@@ -101,6 +101,23 @@ The `fa-icon` function passes args to `text`, so you can customize the icon by p
 
 ```typst #fa-chess-queen(size: 15pt)``` #fa-chess-queen(size: 15pt)
 
+==== Stacking icons
+
+The `fa-stack` function can be used to create stacked icons:
+
+```typst #fa-stack(fa-icon-args: (solid: true), "square", ("chess-queen", (fill: white, size: 5.5pt)))``` #fa-stack(fa-icon-args: (solid: true), "square", ("chess-queen", (fill: white, size: 5.5pt)))
+
+Declaration is `fa-stack(box-args: (:), grid-args: (:), fa-icon-args: (:), ..icons)`
+
+- The order of the icons is from the bottom to the top.
+- `fa-icon-args` is used to set the default args for all icons.
+- You can also control the internal `box` and `grid` by passing the `box-args` and `grid-args` to the `fa-stack` function.
+- Currently, four types of icons are supported. The first three types leverage the `fa-icon` function, and the last type is just a content you want to put in the stack.
+  - `str`, e.g., `"square"`
+  - `array`, e.g., `("chess-queen", (fill: white, size: 5.5pt))`
+  - `arguments`, e.g. `arguments("chess-queen", solid: true, fill: white)`
+  - `content`, e.g. `fa-chess-queen(solid: true, fill: white)`
+
 ==== Known Issues
 
 - #link("https://github.com/typst/typst/issues/2578")[typst\#2578] #link("https://github.com/duskmoon314/typst-fontawesome/issues/2")[typst-fontawesome\#2]

--- a/lib.typ
+++ b/lib.typ
@@ -24,3 +24,49 @@
 ///
 /// Returns: The rendered icon as a `text` element
 #let fa-icon = fa-icon.with(fa-icon-map: fa-icon-map)
+
+/// Render multiple Font Awesome icons together
+///
+/// Parameters:
+/// - `icons`: The list of icons to render
+///   - Each icon can be a string of the icon name or a tuple of the icon name and additional arguments
+///   - For example, `"square"` or `("square", fill: red)`
+/// - `box-args`: Additional arguments to pass to the `box` function
+/// - `grid-args`: Additional arguments to pass to the `grid` function
+/// - `fa-icon-args`: Additional arguments to pass to all `fa-icon` function
+#let fa-stack(
+  box-args: (:),
+  grid-args: (:),
+  fa-icon-args: (:),
+  ..icons,
+) = (
+  context {
+    let icons = icons.pos().map(icon => {
+      if type(icon) == str {
+        fa-icon(icon, ..fa-icon-args)
+      } else {
+        let (name, args) = icon
+        fa-icon(name, ..fa-icon-args, ..args)
+      }
+    })
+
+    // Get the maximum width of the icons
+    let max-width = calc.max(
+      ..icons.map(icon => {
+        measure(icon).width
+      }),
+    )
+
+    box(
+      ..box-args,
+      grid(
+        align: center + horizon,
+        columns: icons.len() * (max-width,),
+        column-gutter: -max-width,
+        rows: 1,
+        ..grid-args,
+        ..icons
+      ),
+    )
+  }
+)

--- a/lib.typ
+++ b/lib.typ
@@ -29,8 +29,11 @@
 ///
 /// Parameters:
 /// - `icons`: The list of icons to render
-///   - Each icon can be a string of the icon name or a tuple of the icon name and additional arguments
-///   - For example, `"square"` or `("square", fill: red)`
+///   - Multiple types are supported:
+///     - `str`: The name of the icon, e.g. `"square"`
+///     - `array`: A tuple of the name and additional arguments, e.g. `("chess-queen", (solid: true, fill: white))`
+///     - `arguments`: Arguments to pass to the `fa-icon` function, e.g. `arguments("chess-queen", solid: true, fill: white)`
+///     - `content`: Any other content you want to render, e.g. `fa-chess-queen(solid: true, fill: white)`
 /// - `box-args`: Additional arguments to pass to the `box` function
 /// - `grid-args`: Additional arguments to pass to the `grid` function
 /// - `fa-icon-args`: Additional arguments to pass to all `fa-icon` function
@@ -44,9 +47,15 @@
     let icons = icons.pos().map(icon => {
       if type(icon) == str {
         fa-icon(icon, ..fa-icon-args)
-      } else {
+      } else if type(icon) == array {
         let (name, args) = icon
         fa-icon(name, ..fa-icon-args, ..args)
+      } else if type(icon) == arguments {
+        fa-icon(..icon.pos(), ..fa-icon-args, ..icon.named())
+      } else if type(icon) == content {
+        icon
+      } else {
+        panic("Unsupported content. Please submit an issue for your use case.")
       }
     })
 


### PR DESCRIPTION
This PR aims to support the stacking icons mentioned in #12.

TODO:
- [x] Doc this feature in README.md and example.typ
- [x] Check the default parameters of internal `box` and `grid`

Current result:

<img width="825" alt="image" src="https://github.com/user-attachments/assets/f814f66b-dced-44ab-bdf5-b40e34c172ee">
